### PR TITLE
Keygen.sh, more documentation, more configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The IRMA keyshare server is a server that performs a share of the IRMA cryptogra
 
 ## Configuring the server
 
-To configure the service you need to setup both irma_configuration and a config file.
+To configure the server you need to setup both `irma_configuration`, a MySQL database, some JWT keys and a config file.
 
 ### irma_configuration
 
@@ -14,15 +14,43 @@ Download or link the `irma_configuration` project to `src/main/resources/`. If b
 
     ln -s ../../../../irma_configuration src/main/resources/
 
+Note that for the irmago tests, you should use the `irma_configuration` folder provided with [irmago](https://github.com/privacybydesign/irmago/tree/master/testdata/irma_configuration)
+
 ### General configuration
 
-You can configure the server at `src/main/resources/config.json`. In the same directory a sample configuration file called `config.sample.json` is included, showing all options, their defaults, and what they mean.
+You can configure the server at `src/main/resources/config.json`. In the same directory a sample configuration file called `config.sample.json` is included, showing all options, their defaults, and what they mean. The sample configuration file should work out of the box for the irmago unit tests (provided you have MailCatcher installed, see below).
+
+### Configuring the database
+
+Create a MySQL database and configure its credentials in:
+
+    src/test/resources/jetty-env.xml
+
+Populate the database with the `database.sql` file with a command like this (assuming user `irma`, password `irma` and database `irma_keyshare`):
+
+    mysql -uirma -pirma irma_keyshare < ./src/main/resources/database.sql
+
+### Generating JWT keys
+
+Run the following script:
+
+    ./utils/preparekeys.sh
+
+This script generates a keypair (`pk.der` and `sk.der`) and copies it to `src/main/resources`. You'll need to copy `pk.der` to your local `irma_api_server` with a command like this:
+
+    cp ./src/main/resources/pk.der ../irma_api_server/src/main/resources/test-kss.der
+
+The `test-` in `test-kss.der` refers to the name of the scheme manager. Rename this appropriately.
+
+### Handling e-mail during development
+
+For development, it can be useful to 'catch' every e-mail that is sent by the server. One can use an application like [MailCatcher](https://mailcatcher.me/) for this. The example configuration file already contains a working config for MaiCatcher.
 
 ## Running the server
 
-The gradle build file should take care the dependencies. To run the server in development mode simply call:
+The gradle build file should take care of the dependencies. To run the server in development mode simply call:
 
-    gradle appRun
+    gradle appRun --no-daemon
 
 ## Server API
 
@@ -31,3 +59,5 @@ The following describes the API offered by the server to an IRMA client.
 ### Register
 
 Before the server can be used for any IRMA protocols, a client needs to register itself with the server.
+
+<!-- vim: set ts=4 sw=4: -->

--- a/src/main/java/org/irmacard/keyshare/web/BaseVerifier.java
+++ b/src/main/java/org/irmacard/keyshare/web/BaseVerifier.java
@@ -120,10 +120,9 @@ public class BaseVerifier {
 			throw new KeyshareException(KeyshareError.USER_BLOCKED, "" + u.getPinblockRelease());
 		}
 
-		if (!u.isEnabled()) {
+		if(!u.isEnabled()) {
 			throw new KeyshareException(KeyshareError.USER_NOT_REGISTERED);
 		}
-
 		return u;
 	}
 }

--- a/src/main/java/org/irmacard/keyshare/web/KeyshareConfiguration.java
+++ b/src/main/java/org/irmacard/keyshare/web/KeyshareConfiguration.java
@@ -37,6 +37,7 @@ public class KeyshareConfiguration {
 	private String mail_password = "";
 	private String mail_host = "";
 	private String mail_from = "";
+	private boolean mail_starttls_required = true;
 	private int mail_port = 587;
 
 	private String webclient_url = "";
@@ -54,6 +55,8 @@ public class KeyshareConfiguration {
 	private String register_email_body = "To finish registering to the keyshare server, please click on the link below.";
 	private String double_registration_email_subject = "Someone tried to re-register this email address";
 	private String double_registration_email_body = "Someone tried to re-register this email address. Was this you? If so, you first need to unregister. If this wasn't you, you can ignore this message.";
+
+	private boolean check_user_enrolled = true;
 
 	private int session_timeout = 30;
 	private int rate_limit = 3;
@@ -112,6 +115,8 @@ public class KeyshareConfiguration {
 	public String getMailHost() {
 		return mail_host;
 	}
+
+	public boolean getStarttlsRequired() { return mail_starttls_required; }
 
 	public int getMailPort() {
 		return mail_port;
@@ -176,6 +181,8 @@ public class KeyshareConfiguration {
 	public String getDoubleRegistrationEmailBody() {
 		return double_registration_email_body;
 	}
+
+	public boolean getCheckUserEnrolled() { return check_user_enrolled; }
 
 	public int getSessionTimeout() {
 		return session_timeout;

--- a/src/main/java/org/irmacard/keyshare/web/PinResource.java
+++ b/src/main/java/org/irmacard/keyshare/web/PinResource.java
@@ -38,7 +38,7 @@ public class PinResource extends BaseVerifier {
 			u.addLog(LogEntryType.PIN_CHECK_REFUSED);
 			throw new KeyshareException(KeyshareError.USER_BLOCKED, "" + u.getPinblockRelease());
 		}
-		if (!u.isEnrolled())
+		if(!u.isEnrolled())
 			throw new KeyshareException(KeyshareError.USER_NOT_REGISTERED);
 
 		if(!u.checkAndCountPin(msg.getPin())) {

--- a/src/main/java/org/irmacard/keyshare/web/Users/User.java
+++ b/src/main/java/org/irmacard/keyshare/web/Users/User.java
@@ -111,7 +111,7 @@ public class User extends Model {
 	}
 
 	public boolean isEnrolled() {
-		return getBoolean(ENROLLED_FIELD);
+		return !KeyshareConfiguration.getInstance().getCheckUserEnrolled() || getBoolean(ENROLLED_FIELD);
 	}
 
 	public void setEnrolled(boolean enrolled) {

--- a/src/main/java/org/irmacard/keyshare/web/VerificationResource.java
+++ b/src/main/java/org/irmacard/keyshare/web/VerificationResource.java
@@ -38,7 +38,7 @@ public class VerificationResource extends BaseVerifier {
 			u.addLog(LogEntryType.IRMA_APP_AUTH_REFUSED);
 			throw new KeyshareException(KeyshareError.USER_BLOCKED, "" + u.getPinblockRelease());
 		}
-		if (!u.isEnrolled()) {
+		if(!u.isEnrolled()) {
 			throw new KeyshareException(KeyshareError.USER_NOT_REGISTERED);
 		}
 

--- a/src/main/java/org/irmacard/keyshare/web/email/EmailSender.java
+++ b/src/main/java/org/irmacard/keyshare/web/email/EmailSender.java
@@ -19,7 +19,7 @@ public class EmailSender {
 			throw new AddressException("Invalid amount of (comma-separated) addresses given (should be 1)");
 
 		Properties props = new Properties();
-		props.put("mail.smtp.starttls.required", "true");
+		props.put("mail.smtp.starttls.required", KeyshareConfiguration.getInstance().getStarttlsRequired());
 		props.put("mail.smtp.port", KeyshareConfiguration.getInstance().getMailPort());
 		props.put("mail.smtp.host", KeyshareConfiguration.getInstance().getMailHost());
 

--- a/src/main/resources/config.sample.json
+++ b/src/main/resources/config.sample.json
@@ -17,5 +17,28 @@
 
     // Optional header that stores the client IP address.
     // I.e. "X-Forwarded-For"
-    "client_ip_header": "X-Forwarded-For"
+    "client_ip_header": "X-Forwarded-For",
+
+    // Name of this keyshare server
+    "server_name": "keyshare_server",
+
+    // Name of the scheme manager (must be present in irma_configuration)
+    "scheme_manager": "test",
+
+    // Name of from address that sends mail
+    "mail_from": "test@test.com",
+
+    // SMTP mail settings, defaulting to mailcatcher https://mailcatcher.me/
+    "mail_host": "127.0.0.1",
+    "mail_port": "1025",
+    "mail_starttls_required": "false",
+
+    // Check if users have verified their e-mail address and aren't blocked
+    // This MUST be enabled for production use, but can be disabled for unit tests like those from irmago
+    "check_user_enrolled": "true",
+
+    // Settings for email issueing
+    "email_issuer": "test",
+    "email_login_credential": "mijnirma",
+    "email_login_attribute": "email"
 }

--- a/utils/keygen.sh
+++ b/utils/keygen.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if openssl exists
+if ! type openssl >/dev/null 2>&1; then
+    >&2 echo "openssl not found, exiting"
+    exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+	SK=sk
+	PK=pk
+fi
+if [[ $# -eq 1 ]]; then
+	>&2 echo "Either supply 0 or 2 arguments"
+	exit 1
+fi
+if [[ $# -eq 2 ]]; then
+	SK=$1
+	PK=$2
+fi
+
+if [ -e ${SK}.der ] || [ -e ${PK}.der ]; then
+    echo "Keys already exist, not generating new ones"
+    exit
+fi
+
+# Generate a private key in PEM format
+openssl genrsa -out ${SK}.pem 2048
+# Convert it to DER for Java
+openssl pkcs8 -topk8 -inform PEM -outform DER -in ${SK}.pem -out ${SK}.der -nocrypt
+# Calculate corresponding public key, saved in PEM format
+openssl rsa -in ${SK}.pem -pubout -outform PEM -out ${PK}.pem
+# Calculate corresponding public key, saved in DER format
+openssl rsa -in ${SK}.pem -pubout -outform DER -out ${PK}.der

--- a/utils/preparekeys.sh
+++ b/utils/preparekeys.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+maindir=$dir/../src/main/resources
+
+# Generate JWT signing keys
+$dir/keygen.sh $maindir/sk $maindir/pk
+rm $maindir/sk.pem 2> /dev/null # Not needed


### PR DESCRIPTION
This PR adds the following improvements:
- More configuration instructions in `README.md`
- Config option to disable starttls for mail server (useful for local mailserver like mailcatcher)
- Config option to disable user enablement checks
- Expanded example configuration file
- Keygen scripts from `irma_api_server`
